### PR TITLE
Support XML response  #6 and add global response counter #9

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,7 @@ source 'https://rubygems.org'
 gem 'newrelic_rpm'
 gem 'sinatra'
 gem 'puma'
+gem 'nokogiri', '1.6.8.1'
 
 gem 'json'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,10 @@ GEM
   remote: https://rubygems.org/
   specs:
     json (1.8.1)
+    mini_portile2 (2.1.0)
     newrelic_rpm (3.9.7.266)
+    nokogiri (1.6.8.1)
+      mini_portile2 (~> 2.1.0)
     puma (2.10.2)
       rack (>= 1.1, < 2.0)
     rack (1.5.2)
@@ -22,6 +25,10 @@ PLATFORMS
 DEPENDENCIES
   json
   newrelic_rpm
+  nokogiri (= 1.6.8.1)
   puma
   shotgun
   sinatra
+
+BUNDLED WITH
+   1.13.1

--- a/echo_api.rb
+++ b/echo_api.rb
@@ -6,6 +6,7 @@ require 'newrelic_rpm'
 require 'nokogiri'
 
 @@random = Random.new
+@@response_counter = 0
 
 enable :logging
 
@@ -37,6 +38,7 @@ def echo_response
         method: request.request_method,
         path: request.path,
         args: request.query_string,
+        counter: @@response_counter += 1,
         body: request.body.read,
         headers: get_headers()
       )
@@ -47,6 +49,7 @@ def echo_response
         xml.method_ request.request_method
         xml.path request.path
         xml.args request.query_string
+        xml.counter = @@response_counter += 1
         xml.body request.body.read
         xml.headers { |headers|
           get_headers().each_pair do |key, value|
@@ -101,6 +104,9 @@ get '/wait/:seconds' do |seconds|
 
   Kernel.sleep(duration)
   body "slept #{duration} seconds"
+end
+
+get '/favicon.ico' do # Avoid bumping counter on favicon
 end
 
 all_methods "/**" do

--- a/echo_api.rb
+++ b/echo_api.rb
@@ -1,9 +1,11 @@
 #shotgun app.rb -p 9294
 
 require 'sinatra'
-require "json"
-
+require 'json'
 require 'newrelic_rpm'
+require 'nokogiri'
+
+@@random = Random.new
 
 enable :logging
 
@@ -29,18 +31,36 @@ end
 
 def echo_response
   request.body.rewind
-
-  content_type 'application/json'
-  JSON.pretty_generate(
-    method: request.request_method,
-    path: request.path,
-    args: request.query_string,
-    body: request.body.read,
-    headers: get_headers()
-  )
+  if request.accept?('application/json')
+      content_type 'application/json'
+      JSON.pretty_generate(
+        method: request.request_method,
+        path: request.path,
+        args: request.query_string,
+        body: request.body.read,
+        headers: get_headers()
+      )
+  else
+    content_type 'application/xml'
+    builder = Nokogiri::XML::Builder.new do |xml|
+      xml.echoResponse {
+        xml.method_ request.request_method
+        xml.path request.path
+        xml.args request.query_string
+        xml.body request.body.read
+        xml.headers { |headers|
+          get_headers().each_pair do |key, value|
+            headers.header { |header|
+              header.key key.split('HTTP_')[1]
+              header.value value
+            }
+          end
+        }
+      }
+    end
+    builder.to_xml
+  end
 end
-
-@@random = Random.new
 
 def random_file(name, size)
   path = Pathname.new('tmp').join('size', name)
@@ -56,7 +76,6 @@ def random_file(name, size)
 
   path
 end
-
 
 get '/size/:size' do |original_size|
   size, unit = original_size.scan(/\d+|\D+/)
@@ -83,7 +102,6 @@ get '/wait/:seconds' do |seconds|
   Kernel.sleep(duration)
   body "slept #{duration} seconds"
 end
-
 
 all_methods "/**" do
   echo_response


### PR DESCRIPTION
```
{
  "method": "GET",
  "path": "/foo/bar",
  "args": "baz=alpha",
  "body": "",
  "counter": 5,
  "headers": {
    "HTTP_VERSION": "HTTP/1.1",
    "HTTP_HOST": "localhost:3000",
    "HTTP_CONNECTION": "keep-alive",
    "HTTP_UPGRADE_INSECURE_REQUESTS": "1",
    "HTTP_USER_AGENT": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/54.0.2840.87 Safari/537.36",
    "HTTP_ACCEPT": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8",
    "HTTP_ACCEPT_ENCODING": "gzip, deflate, sdch, br",
    "HTTP_ACCEPT_LANGUAGE": "en-GB,en;q=0.8,en-US;q=0.6,es;q=0.4"
  }
}
```

```
<?xml version="1.0"?>
<echoResponse>
  <method>POST</method>
  <path>/a/b/c</path>
  <args>a=2</args>
  <body>foo</body>
  <counter>1</counter>
  <headers>
    <header>
      <key>VERSION</key>
      <value>HTTP/1.1</value>
    </header>
    <header>
      <key>HOST</key>
      <value>localhost:3000</value>
    </header>
    <header>
      <key>USER_AGENT</key>
      <value>curl/7.49.1</value>
    </header>
    <header>
      <key>ACCEPT</key>
      <value>application/xml</value>
    </header>
  </headers>
</echoResponse>
```

@EricWittmann See above. Other features will be separate PR(s).