### PR TITLE
Support XML response #6 and add global response counter #9

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,7 @@ source 'https://rubygems.org'
 gem 'newrelic_rpm'
 gem 'sinatra'
 gem 'puma'
+gem 'nokogiri', '1.6.8.1'
 
 gem 'json'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,10 @@ GEM
   remote: https://rubygems.org/
   specs:
     json (1.8.1)
+    mini_portile2 (2.1.0)
     newrelic_rpm (3.9.7.266)
+    nokogiri (1.6.8.1)
+      mini_portile2 (~> 2.1.0)
     puma (2.10.2)
       rack (>= 1.1, < 2.0)
     rack (1.5.2)
@@ -22,6 +25,10 @@ PLATFORMS
 DEPENDENCIES
   json
   newrelic_rpm
+  nokogiri (= 1.6.8.1)
   puma
   shotgun
   sinatra
+
+BUNDLED WITH
+   1.13.1

--- a/echo_api.rb
+++ b/echo_api.rb
@@ -32,17 +32,8 @@ end
 
 def echo_response
   request.body.rewind
-  if request.accept?('application/json')
-      content_type 'application/json'
-      JSON.pretty_generate(
-        method: request.request_method,
-        path: request.path,
-        args: request.query_string,
-        uuid: SecureRandom.uuid(),
-        body: request.body.read,
-        headers: get_headers()
-      )
-  else
+  # Prefer JSON if possible, including cases of unrecognised/erroneous types.
+  if request.accept?('application/xml') && !request.accept?('application/json')
     content_type 'application/xml'
     builder = Nokogiri::XML::Builder.new do |xml|
       xml.echoResponse {
@@ -69,6 +60,16 @@ def echo_response
       }
     end
     builder.to_xml
+  else
+    content_type 'application/json'
+    JSON.pretty_generate(
+      method: request.request_method,
+      path: request.path,
+      args: request.query_string,
+      uuid: SecureRandom.uuid(),
+      body: request.body.read,
+      headers: get_headers()
+    )
   end
 end
 

--- a/echo_api.rb
+++ b/echo_api.rb
@@ -6,6 +6,7 @@ require 'newrelic_rpm'
 require 'nokogiri'
 
 @@random = Random.new
+@@response_counter = 0
 
 enable :logging
 
@@ -37,6 +38,7 @@ def echo_response
         method: request.request_method,
         path: request.path,
         args: request.query_string,
+        counter: @@response_counter += 1,
         body: request.body.read,
         headers: get_headers()
       )
@@ -46,6 +48,7 @@ def echo_response
       xml.echoResponse {
         xml.method_ request.request_method
         xml.path request.path
+        xml.counter @@response_counter += 1
         xml.body request.body.read
         xml.headers { |headers|
           get_headers().each_pair do |key, value|
@@ -108,6 +111,9 @@ get '/wait/:seconds' do |seconds|
 
   Kernel.sleep(duration)
   body "slept #{duration} seconds"
+end
+
+get '/favicon.ico' do # Avoid bumping counter on favicon
 end
 
 all_methods "/**" do

--- a/echo_api.rb
+++ b/echo_api.rb
@@ -4,9 +4,9 @@ require 'sinatra'
 require 'json'
 require 'newrelic_rpm'
 require 'nokogiri'
+require 'securerandom'
 
 @@random = Random.new
-@@response_counter = 0
 
 enable :logging
 
@@ -38,7 +38,7 @@ def echo_response
         method: request.request_method,
         path: request.path,
         args: request.query_string,
-        counter: @@response_counter += 1,
+        uuid: SecureRandom.uuid(),
         body: request.body.read,
         headers: get_headers()
       )
@@ -48,7 +48,7 @@ def echo_response
       xml.echoResponse {
         xml.method_ request.request_method
         xml.path request.path
-        xml.counter @@response_counter += 1
+        xml.uuid SecureRandom.uuid()
         xml.body request.body.read
         xml.headers { |headers|
           get_headers().each_pair do |key, value|


### PR DESCRIPTION
```
{
  "method": "GET",
  "path": "/foo/bar",
  "args": "baz=alpha",
  "body": "",
  "counter": 5,
  "headers": {
    "HTTP_VERSION": "HTTP/1.1",
    "HTTP_HOST": "localhost:3000",
    "HTTP_CONNECTION": "keep-alive",
    "HTTP_UPGRADE_INSECURE_REQUESTS": "1",
    "HTTP_USER_AGENT": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/54.0.2840.87 Safari/537.36",
    "HTTP_ACCEPT": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8",
    "HTTP_ACCEPT_ENCODING": "gzip, deflate, sdch, br",
    "HTTP_ACCEPT_LANGUAGE": "en-GB,en;q=0.8,en-US;q=0.6,es;q=0.4"
  }
}
```

```
<echoResponse>
  <method>POST</method>
  <path>/a/b/c</path>
  <counter>9</counter>
  <body>foo</body>
  <headers>
    <header>
      <key>VERSION</key>
      <value>HTTP/1.1</value>
    </header>
    <header>
      <key>HOST</key>
      <value>localhost:3000</value>
    </header>
    <header>
      <key>USER_AGENT</key>
      <value>curl/7.49.1</value>
    </header>
    <header>
      <key>ACCEPT</key>
      <value>application/xml</value>
    </header>
  </headers>
  <args>
    <arg>
      <key>a</key>
      <value>2</value>
    </arg>
  </args>
</echoResponse>
```

@EricWittmann See above. Other features will be separate PR(s).

Yes, the XML is a bit verbose. But that's XML for you :-).