### PR TITLE
Fold readme.md into README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,3 +2,5 @@ echo-api
 ========
 
 Stupid sinatra app that returns back info about the request 
+
+http://echo-api.herokuapp.com/ 

--- a/readme.md
+++ b/readme.md
@@ -1,1 +1,0 @@
-http://echo-api.herokuapp.com/ 


### PR DESCRIPTION
Mac OS X "case insensitive but case preserving" really
hates two files whose names with only case differences.