### PR TITLE
Echo headers

### DIFF
--- a/echo_api.rb
+++ b/echo_api.rb
@@ -48,16 +48,16 @@ def echo_response
   # Return all request headers like
   #   ECHO.*: <foo>: <bar> as a response header <foo>: <bar>
   #   ECHO.*: <baz>        as a response header <baz>:
-  get_echoable_headers.each do |h|
-    if h[1] =~ /:/
-      header, value = h[1].split(':')
-      value.strip!
+  get_echoable_headers.each do |(_header, value)|
+    if value =~ /:/
+      response_header, response_value = value.split(':')
+      response_value.strip!
     else
-      header = h[1]
-      value = ' '
+      response_header = value
+      response_value = ' '
     end
 
-    headers[header] = value
+    headers[response_header] = response_value
   end
 
   response_args = {

--- a/echo_api.rb
+++ b/echo_api.rb
@@ -32,6 +32,10 @@ def get_headers
   env.select {|k, v| k.start_with? 'HTTP_'}
 end
 
+def get_echoable_headers
+  get_headers().select {|k, v| k.start_with? 'HTTP_ECHO'}
+end
+
 def echo_response
   body = request.body.read
   hash = Digest::SHA1.base64digest(body)
@@ -39,6 +43,21 @@ def echo_response
   if request.media_type == 'application/octet-stream' ||
       request.media_type == 'multipart/form-data' || body =~ /[^[:print:]]/
     body = Base64.encode64(body)
+  end
+
+  # Return all request headers like
+  #   ECHO.*: <foo>: <bar> as a response header <foo>: <bar>
+  #   ECHO.*: <baz>        as a response header <baz>:
+  get_echoable_headers.each do |h|
+    if h[1] =~ /:/
+      header, value = h[1].split(':')
+      value.strip!
+    else
+      header = h[1]
+      value = ' '
+    end
+
+    headers[header] = value
   end
 
   response_args = {

--- a/echo_api.rb
+++ b/echo_api.rb
@@ -33,7 +33,7 @@ def get_headers
 end
 
 def get_echoable_headers
-  get_headers().select {|k, v| k.start_with? 'HTTP_ECHO'}
+  get_headers().select {|k, v| k.start_with? 'HTTP_ECHO_'}
 end
 
 def echo_response
@@ -46,18 +46,16 @@ def echo_response
   end
 
   # Return all request headers like
-  #   ECHO.*: <foo>: <bar> as a response header <foo>: <bar>
-  #   ECHO.*: <baz>        as a response header <baz>:
-  get_echoable_headers.each do |(_header, value)|
-    if value =~ /:/
-      response_header, response_value = value.split(':')
-      response_value.strip!
-    else
-      response_header = value
-      response_value = ' '
-    end
+  #   ECHO_<foo>: <bar> as a response header <foo>: <bar>
+  #   ECHO_<baz>        as a response header <baz>:
+  get_echoable_headers.each do |(header, value)|
+    response_header = header
+                        .gsub(/HTTP_ECHO_/, '')
+                        .split('_')
+                        .collect(&:capitalize)
+                        .join('-')
 
-    headers[response_header] = response_value
+    headers[response_header] = value
   end
 
   response_args = {


### PR DESCRIPTION
Currently, all content is echoed back to the caller in the response body.  This change allows the caller to request that content is echoed back as a response header.

    For example:
    
    ```
    curl -v -H"ECHO1: foo: bar" \
            -H"ECHO2: Cache-Control: public, max-age=3600" \
            -H"ECHO3: blarch" http://localhost:8000/foo
    ```
    
    Will return a response like:
    
    ```
    < HTTP/1.1 200 OK
    < Content-Type: application/json
    < foo: bar
    < Cache-Control: public, max-age=3600
    < blarch:
    < X-Content-Type-Options: nosniff
    < Content-Length: 382
    ```

Motivating use case: allow `echo-api` to act as a [varnish](https://varnish-cache.org/) backend for some VCL development/testing.
