### PR TITLE
Clarified ECHOAPI_HOST parameter in the README.md file

### DIFF
--- a/openshift/README.md
+++ b/openshift/README.md
@@ -45,7 +45,7 @@ oc new-project echo-api
 - Create the template:
 
 ```
-oc new-app -f echo-api-template.yml
+oc new-app -f echo-api-template.yml --param ECHOAPI_HOST=<a-hostname-for-echo-api-route>
 ```
 
 - Check status:

--- a/openshift/echo-api-template.yml
+++ b/openshift/echo-api-template.yml
@@ -93,5 +93,4 @@ parameters:
 
 - name: ECHOAPI_HOST
   description: "Host for the Route Object"
-  value: "yourhost.com"
   required: true


### PR DESCRIPTION
The default `ECHOAPI_HOST` value is not valid, it should be described at all times.