### PR TITLE
Move production image to UBI8 and add development environment

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,9 +1,12 @@
-#Ignore documentation files
-	*.md
-
-#Ignore License 
-	LICENSE
-
-#Ignore Makefile and Dockerfile
-	Makefile
-	Dockerfile
+./.bundle
+./.dockerignore
+./.gitignore
+./.git
+./.circleci
+./Makefile
+./Dockerfile
+./istio
+./openshift
+./*.md
+./LICENSE
+./NOTICE

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,40 +1,76 @@
-# Please use the echo-api repository to open any issues with this file.
-FROM centos:7
-LABEL authors="Oriol Martí <oriol@3scale.net>,Daniel Cesario <dcesario@redhat.com>"
-
-ENV RUBY_VERSION="rh-ruby26"
-
-RUN yum -y update \
-  && yum install -y centos-release-scl \
-  && yum install -y \
-    gcc \
-    patch \
-    make \
-    openssl-devel \
-    ${RUBY_VERSION} \
-    ${RUBY_VERSION}-ruby-devel \
-  && yum clean all
-
-WORKDIR /opt/echo-api/
-
-COPY ./ /opt/echo-api
-COPY contrib/scl_enable /opt/echo-api/etc/
-
-RUN source /opt/echo-api/etc/scl_enable \
-  && gem install -N bundler \
-  && gem env \
-  && bundle config --global silence_root_warning 1
-
-ENV BASH_ENV=/opt/echo-api/etc/scl_enable \
-    ENV=/opt/echo-api/etc/scl_enable \
-    PROMPT_COMMAND=". /opt/echo-api/etc/scl_enable" \
-  BUNDLE_WITHOUT=development:test
-
-RUN source /opt/echo-api/etc/scl_enable \
-  && bundle install --deployment
+# Common base image
+FROM registry.access.redhat.com/ubi8/ubi-minimal AS base
 
 EXPOSE 9292
 
-USER 1001
-ENTRYPOINT ["/opt/echo-api/entrypoint.sh"]
-CMD ["rackup", "config.ru", "-o", "0.0.0.0"]
+ENV HOME=/home
+WORKDIR "${HOME}/app"
+
+ARG RUBY_VERSION="2.6"
+ARG BUNDLER_VERSION="2.1.4"
+ARG RUNTIME_DEPS="ruby"
+
+# TODO: microdnf currently contains a nasty bug in which using --nodocs or --setopt=tsflags=nodocs fails
+RUN echo -e "[ruby]\nname=ruby\nstream=${RUBY_VERSION}\nprofiles=\nstate=enabled\n" > /etc/dnf/modules.d/ruby.module \
+  && microdnf update \
+  && microdnf install ${RUNTIME_DEPS} \
+  && gem install -N bundler -v "= ${BUNDLER_VERSION}" \
+  && chown -R 1001:1001 "${HOME}"
+
+# Build image without source code (useful for dev image)
+FROM base AS builder-base
+
+ARG BUILD_DEPS="tar make file findutils git patch gcc automake autoconf libtool redhat-rpm-config openssl-devel ruby-devel"
+
+RUN microdnf install ${BUILD_DEPS}
+
+COPY --chown=1001:1001 ./Gemfile* "${HOME}/app/"
+
+USER 1001:1001
+
+FROM builder-base AS builder-with-gems
+RUN bundle config --global without 'test development' \
+  && bundle config --global deployment 'true' \
+  && bundle install
+
+# Build image with source code
+FROM builder-with-gems AS builder
+
+# Copy sources
+COPY --chown=1001:1001 ./ "${HOME}/app/"
+
+# Runtime image
+FROM base AS production
+MAINTAINER Alejandro Martinez Ruiz <amr@redhat.com>
+
+USER 1001:1001
+
+# Copy over the whole bundle
+COPY --chown=1001:1001 --from=builder "${HOME}/" "${HOME}/"
+
+CMD ["bundle", "exec", "rackup", "-o", "0.0.0.0"]
+
+# Development image
+FROM builder-base AS dev
+
+USER root
+
+ARG DEV_TOOLS="vim gdb"
+RUN microdnf install ${DEV_TOOLS}
+
+ARG DEV_UID=1001
+ARG DEV_GID=1001
+ENV DEV_UID=${DEV_UID} DEV_GID=${DEV_GID} PATH="${PATH}:${HOME}/bin"
+
+RUN chown -R ${DEV_UID}:${DEV_GID} "${HOME}"
+
+USER ${DEV_UID}:${DEV_GID}
+
+RUN bundle config --global with 'test development' \
+  && bundle config --global silence_root_warning 1 \
+  && bundle config --global bin "${HOME}/bin" \
+  && bundle config --global path "${HOME}/gems" \
+  && bundle install
+
+CMD ["/bin/bash"]
+

--- a/Makefile
+++ b/Makefile
@@ -3,9 +3,12 @@
 NAME = echoapi
 NAMESPACE = quay.io/3scale
 VERSION ?= new-echoapi
-DOCKER ?= $(shell which podman 2> /dev/null || echo docker)
+DOCKER ?= $(shell which podman 2> /dev/null || which docker 2> /dev/null || echo docker)
 LOCAL_IMAGE := $(NAME):$(VERSION)
+BUILDER_IMAGE := $(LOCAL_IMAGE)-builder
+DEV_IMAGE := $(LOCAL_IMAGE)-dev
 REMOTE_IMAGE := $(NAMESPACE)/$(LOCAL_IMAGE)
+DEV_CONTAINER := $(NAME)-dev
 
 MKFILE_PATH := $(abspath $(lastword $(MAKEFILE_LIST)))
 THISDIR_PATH := $(patsubst %/,%,$(abspath $(dir $(MKFILE_PATH))))
@@ -16,31 +19,90 @@ all: build
 
 update: build test push
 
-build: ## Build docker image with name LOCAL_IMAGE (NAME:VERSION).
-	$(DOCKER) build -f $(THISDIR_PATH)/Dockerfile -t $(LOCAL_IMAGE) $(PROJECT_PATH)
+build: ## Build container image with name LOCAL_IMAGE (NAME:VERSION).
+	$(DOCKER) build --target production -f $(THISDIR_PATH)/Dockerfile -t $(LOCAL_IMAGE) $(PROJECT_PATH)
+
+build-builder:
+	$(DOCKER) build --target builder -f $(THISDIR_PATH)/Dockerfile -t $(BUILDER_IMAGE) $(PROJECT_PATH)
+
+build-dev: ## Build a development container image with name LOCAL_IMAGE (NAME:VERSION).
+	@$(DOCKER) history -q $(BUILDER_IMAGE) 2> /dev/null >&2 || $(MAKE) -C $(PROJECT_PATH) -f $(MKFILE_PATH) build-builder
+	if echo "$(DOCKER)" | grep -q podman; then \
+		DEV_UID=0; \
+		DEV_GID=0; \
+	else \
+		DEV_UID=$$(id -u); \
+		DEV_GID=$$(id -g); \
+	fi && \
+	$(DOCKER) build --target dev -f $(THISDIR_PATH)/Dockerfile -t $(DEV_IMAGE) --build-arg DEV_UID=$${DEV_UID} --build-arg DEV_GID=$${DEV_GID} $(PROJECT_PATH)
+	@echo "Dev image ready."
+
+stop-dev: ## Stop the development container
+	$(DOCKER) stop $(DEV_CONTAINER)
+
+clean-dev: ## Remove the development container
+	-$(MAKE) -C $(PROJECT_PATH) -f $(MKFILE_PATH) stop-dev
+	$(DOCKER) rm $(DEV_CONTAINER)
+
+clean-dev-image: ## Remove the develpoment image
+	-$(MAKE) -C $(PROJECT_PATH) -f $(MKFILE_PATH) clean-dev
+	$(DOCKER) rmi $(DEV_IMAGE)
+
+clean-builder-image: ## Remove the builder image
+	-$(MAKE) -C $(PROJECT_PATH) -f $(MKFILE_PATH) clean-dev-image
+	$(DOCKER) rmi $(BUILDER_IMAGE)
 
 test: ## Test built LOCAL_IMAGE (NAME:VERSION).
-	$(DOCKER) run --rm -u 10000001 --name $(VERSION) -t -p 9292:9292 -d $(LOCAL_IMAGE)
-	@sleep 1
-	curl localhost:9292
-	$(DOCKER) kill $(VERSION)
+	@$(DOCKER) history -q $(LOCAL_IMAGE) 2> /dev/null >&2 || $(MAKE) -C $(PROJECT_PATH) -f $(MKFILE_PATH) build
+	$(DOCKER) run --rm \
+		--name $(VERSION) -t -p 9292:9292 -d $(LOCAL_IMAGE)
+	@sleep 2
+	curl -v "http://localhost:9292"
+	@$(DOCKER) kill $(VERSION)
+	@echo "Test OK."
 
-run: ## Run the docker in the local machine.
-	$(DOCKER) run --rm -u 10000001 -t -P $(LOCAL_IMAGE)
+run: ## Run the container in the local machine.
+	@$(DOCKER) history -q $(LOCAL_IMAGE) 2> /dev/null >&2 || $(MAKE) -C $(PROJECT_PATH) -f $(MKFILE_PATH) build
+	$(DOCKER) run --rm \
+		-u $$($(DOCKER) run --rm $(LOCAL_IMAGE) /bin/bash -c 'id -u'):$$($(DOCKER) run --rm $(LOCAL_IMAGE) /bin/bash -c 'id -g') \
+		-t -P $(LOCAL_IMAGE)
 
 bash: ## Start bash in the build IMAGE_NAME.
-	$(DOCKER) run --rm --entrypoint=/bin/bash -it $(LOCAL_IMAGE)
+	@$(DOCKER) history -q $(LOCAL_IMAGE) 2> /dev/null >&2 || $(MAKE) -C $(PROJECT_PATH) -f $(MKFILE_PATH) build
+	$(DOCKER) run --rm -ti $(LOCAL_IMAGE) /bin/bash
 
+dev: ## Start a development environment sync'ed with the code
+	@$(DOCKER) history -q $(DEV_IMAGE) 2> /dev/null >&2 || $(MAKE) -C $(PROJECT_PATH) -f $(MKFILE_PATH) build-dev
+	@if $(DOCKER) ps --filter name=$(DEV_CONTAINER) --format "{{.Names}}" | grep -q '^$(DEV_CONTAINER)$$' 2> /dev/null >&2; then \
+		echo "Container $(DEV_CONTAINER) already started" >&2; false; \
+	fi
+	@if $(DOCKER) ps -a --filter name=$(DEV_CONTAINER) --format "{{.Names}}" | grep -q '^$(DEV_CONTAINER)$$' 2> /dev/null >&2; then \
+		echo "Resuming existing $(DEV_CONTAINER) container." ; \
+		$(DOCKER) start -ai $(DEV_CONTAINER) ; \
+	else \
+		if echo "$(DOCKER)" | grep -q podman; then \
+			EXTRA_OPTS=""; \
+		else \
+			EXTRA_OPTS="-u $$(id -u):$$(id -g) --group-add 1001"; \
+	        fi && \
+		echo "Creating new $(DEV_CONTAINER) container." ; \
+		$(DOCKER) run -ti -h $(DEV_CONTAINER) --expose=9292 -p 9292:9292 \
+		-v $(THISDIR_PATH):$$($(DOCKER) run --rm $(DEV_IMAGE) /bin/bash -c 'pwd'):z \
+		$${EXTRA_OPTS} \
+		--name $(DEV_CONTAINER) $(DEV_IMAGE) /bin/bash ; \
+	fi
 
-tag: ## Tag IMAGE_NAME in the docker registry
+tag: ## Tag IMAGE_NAME in the container registry
+	@$(DOCKER) history -q $(LOCAL_IMAGE) 2> /dev/null >&2 || $(MAKE) -C $(PROJECT_PATH) -f $(MKFILE_PATH) build
 	$(DOCKER) tag $(LOCAL_IMAGE) $(REMOTE_IMAGE)
 
-push: tag ## Push to the docker registry
+push: tag ## Push to the container registry
 	$(DOCKER) push $(REMOTE_IMAGE)
 
-pull: ## Pull the docker from the Registry
+pull: ## Pull the container from the Registry
 	$(DOCKER) pull $(REMOTE_IMAGE)
 
 # Check http://marmelab.com/blog/2016/02/29/auto-documented-makefile.html
 help: ## Print this help
+	@echo -e "Set the DOCKER variable to your docker-compatible program (Docker and Podman supported)\n"
 	@awk 'BEGIN {FS = ":.*?## "} /^[a-zA-Z_-]+:.*?## / {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}' $(MAKEFILE_LIST)

--- a/contrib/scl_enable
+++ b/contrib/scl_enable
@@ -1,4 +1,0 @@
-# This file contains automatic SCL enablement.
-unset BASH_ENV PROMPT_COMMAND ENV
-export GEM_PATH=/opt/rh/rh-ruby26/root/usr/local/share/gems:/opt/rh/rh-ruby26/root/usr/share/gems
-source scl_source enable rh-ruby26

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,3 +1,0 @@
-#!/bin/bash
-
-exec bundle exec "$@"


### PR DESCRIPTION
This PR modernizes this app for proper maintenance, and upgrades the production image to RHEL8.

- [x] Reduce image size by using UBI8 minimal image.
- [x] Use newer, supported Ruby streams.
- [x] Leverage a single multi-stage Dockerfile sharing the same environment between prod & dev.
- [x] Add development container to ease maintenance and updates.
- [x] Support rootless Podman (tested 1.7.0).
- [x] Support latest Docker version (tested 19.03.5).

As before, `podman` will be used by default if found, falling back to docker otherwise. You can still force the docker "implementation" by setting `DOCKER=$(which docker)` when invoking `make`.

New interesting targets include `dev` for the _persistent_ development container, and `clean-dev`, and `clean-dev-image` to remove the container or the container and the image, respectively.

`make build` now produces a RHEL 8-based Universal Base Image via the minimal version (so it uses microdnf). While image size is greatly reduced, there is still room for a bit more once upstream `dnf` developers fix https://bugzilla.redhat.com/show_bug.cgi?id=1784427 and related issues.

### Notes

- The build and runtime dependencies are specified in the `Dockerfile` as arguments. There is no direct support to specify those out of the `Makefile`, but that is hardly an issue since these tend to not vary at all.
- The usage of `podman` for the development image is intended to be [`rootless`](https://opensource.com/article/19/2/how-does-rootless-podman-work). There are still some bugs and kinks to iron out there (especially with image layer caches and mapping host to container user ids), but it is functional _while running as *root* in the container_. Note that this is not any less secure (in fact, quite likely it is more secure) than running a Docker container with a non-privileged user, since the whole process never gets anywhere close to the host's real root user, and escaping such a container would end up with your normal user privileges.
- The version of Bundler is passed in as an argument, with the latest Bundler as of writing as default. Since the current Bundler package in the Ruby appstreams module is older than what's needed by the app's Gemfile.lock, a modern Bundler is installed from Rubygems. Once this catches up to Bundler 2 (hopefully in the 2.7 stream) there is the _possibility_ of just installing the `rubygem-bundler` package. Whether that is the right thing to do or not would be a different matter altogether.
- The version of Ruby is passed in as an argument featuring the major and minor numbers only, with the current application's Ruby (2.6) as default. These map to RHEL 8's Ruby module streams, so you can't just specify any value here: it must exist as a stream, and patch-level versions are not configurable since the latest available .z version will be taken (which means no 100% full reproducibility, but close to it with security and bug fixes applied).
- Docker runs the development environment as an unprivileged user. This means that you won't be able to install additional software within the container. This will currently require you to change either the Dockerfile or Makefile to specify the `DEV_TOOLS` argument so it is installed when building the development image. Alternatively you could modify the Dockerfile to install `sudo` and register the container user to the appropriate group.