### PR TITLE
Gemfiles: relax dependencies on puma, rack and nokogiri and update

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,9 +2,9 @@
 
 source 'https://rubygems.org'
 
-gem 'nokogiri', '1.10.7'
+gem 'nokogiri', '~> 1'
 gem 'puma'
-gem 'rack', '2.0.8'
+gem 'rack', '~> 2'
 gem 'rack-cors', require: 'rack/cors'
 gem 'sinatra'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,20 +6,22 @@ GEM
       thrift
     json (2.3.0)
     mini_portile2 (2.4.0)
-    mustermann (1.1.0)
+    mustermann (1.1.1)
       ruby2_keywords (~> 0.0.1)
+    nio4r (2.5.2)
     nokogiri (1.10.7)
       mini_portile2 (~> 2.4.0)
     opentracing (0.4.1)
-    puma (3.12.2)
-    rack (2.0.8)
+    puma (4.3.1)
+      nio4r (~> 2.0)
+    rack (2.1.2)
     rack-cors (1.1.1)
       rack (>= 2.0.0)
     rack-protection (2.0.8.1)
       rack
     rack-tracer (0.9.0)
       opentracing (~> 0.4)
-    ruby2_keywords (0.0.1)
+    ruby2_keywords (0.0.2)
     shotgun (0.9.2)
       rack (>= 1.0)
     sinatra (2.0.8.1)
@@ -38,10 +40,10 @@ PLATFORMS
 DEPENDENCIES
   jaeger-client (= 0.6.1)
   json
-  nokogiri (= 1.10.7)
+  nokogiri (~> 1)
   opentracing (= 0.4.1)
   puma
-  rack (= 2.0.8)
+  rack (~> 2)
   rack-cors
   rack-tracer (= 0.9.0)
   shotgun
@@ -49,4 +51,4 @@ DEPENDENCIES
   spanmanager (= 0.3.0)
 
 BUNDLED WITH
-   2.0.2
+   2.1.4


### PR DESCRIPTION
Bump Puma, Rack and Nokogiri, and relax the version constraints, since we don't really require them to be strict.