### PR TITLE
Gemfiles: update opentracing and jaeger-client

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,8 +11,8 @@ gem 'sinatra'
 gem 'json'
 
 # Opentracing
-gem 'jaeger-client', '0.6.1'
-gem 'opentracing', '0.4.1'
+gem 'jaeger-client', '~> 1'
+gem 'opentracing', '~> 0.5'
 gem 'rack-tracer', '0.9.0'
 gem 'spanmanager', '= 0.3.0'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    jaeger-client (0.6.1)
+    jaeger-client (1.0.0)
       opentracing (~> 0.3)
       thrift
     json (2.3.0)
@@ -11,7 +11,7 @@ GEM
     nio4r (2.5.2)
     nokogiri (1.10.7)
       mini_portile2 (~> 2.4.0)
-    opentracing (0.4.1)
+    opentracing (0.5.0)
     puma (4.3.1)
       nio4r (~> 2.0)
     rack (2.1.2)
@@ -38,10 +38,10 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  jaeger-client (= 0.6.1)
+  jaeger-client (~> 1)
   json
   nokogiri (~> 1)
-  opentracing (= 0.4.1)
+  opentracing (~> 0.5)
   puma
   rack (~> 2)
   rack-cors


### PR DESCRIPTION
These two work together, although the gem we use directly, rack-tracer,
has not been updated to use any new feature.