### PR TITLE
openshift,istio: switch image to the stable floating tag

### DIFF
--- a/istio/deployment.yaml
+++ b/istio/deployment.yaml
@@ -28,7 +28,7 @@ spec:
     spec:
       containers:
       - name: echo-api
-        image: quay.io/3scale/echoapi:master
+        image: quay.io/3scale/echoapi:stable
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9292

--- a/openshift/echo-api-template.yml
+++ b/openshift/echo-api-template.yml
@@ -87,7 +87,7 @@ objects:
 parameters:
 - name: ECHOAPI_IMAGE
   description: "Docker image to the Echo API"
-  value: "quay.io/3scale/echoapi:master"
+  value: "quay.io/3scale/echoapi:stable"
   required: true
 
 


### PR DESCRIPTION
This changes the container image reference in the provided templates to the `stable` floating tag. That should point from now on to the latest stable version as it is released. Note that people actually deploying this might want to change it to specific images and manage this at their own pace, as in cases of breaking changes this will still be updated.

This will close #159.