### PR TITLE
Dockerfile,Gemfile.lock: update Bundler to 2.2.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ ENV HOME=/home
 WORKDIR "${HOME}/app"
 
 ARG RUBY_VERSION="2.7"
-ARG BUNDLER_VERSION="2.2.1"
+ARG BUNDLER_VERSION="2.2.4"
 ARG RUNTIME_DEPS="ruby"
 
 RUN echo -e "[ruby]\nname=ruby\nstream=${RUBY_VERSION}\nprofiles=\nstate=enabled\n" > /etc/dnf/modules.d/ruby.module \

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -48,4 +48,4 @@ DEPENDENCIES
   sinatra
 
 BUNDLED WITH
-   2.2.1
+   2.2.4


### PR DESCRIPTION
This should fix the issues seen on OpenShift with Bundler not starting.

N.B. Bundler still spits out a warning about not being able to write,
but now it keeps running.